### PR TITLE
Update to PIL 1.1.7

### DIFF
--- a/src/base.cfg
+++ b/src/base.cfg
@@ -9,8 +9,8 @@ find-links =
     ${buildout:python-buildout-root}
 versions = versions
 
-# pil-install-args = -f http://dist.repoze.org/ -U PIL==1.1.7
-pil-install-args = Pillow
+pil-install-args = -f http://dist.repoze.org/ -U PIL==1.1.7
+# pil-install-args = Pillow
 
 [versions]
 monkeycmmi = 0.2


### PR DESCRIPTION
PIL 1.1.6 has been failing to build for Python 2.4 under Ubuntu 12.04. Bumping up the version to 1.1.7 solved the problem.
