### PR TITLE
Python 3.3.0 needs virtualenv 1.8.2

### DIFF
--- a/src/base.cfg
+++ b/src/base.cfg
@@ -27,6 +27,6 @@ dummy-dependencies = ${opt:recipe}
 
 [virtualenv]
 recipe = hexagonit.recipe.download
-url = http://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.7.2.tar.gz
-md5sum = b5d63b05373a4344ae099a68875aae78
+url = http://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.8.2.tar.gz
+md5sum = 174ca075c6b1a42c685415692ec4ce2e
 strip-top-level-dir = true


### PR DESCRIPTION
Pip 1.1 is incompatible with Python 3.3.0, at least on OS X. See Change log in http://pypi.python.org/pypi/virtualenv and https://github.com/pypa/virtualenv/issues/322.
