### PR TITLE
Pin down Pillow to 1.x for python 2.4 and 2.5.

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -1,6 +1,13 @@
 Changes
 =======
 
+2013-03-16
+----------
+
+- Pin down Pillow to 1.x for python 2.4 and 2.5.
+  Pillow 2.x supports only python >= 2.6
+  [jone]
+
 2013-01-08
 ----------
 

--- a/src/python24.cfg
+++ b/src/python24.cfg
@@ -9,6 +9,8 @@ python24-parts =
     python-2.4-test
 #    python-2.4-buildout
 
+python24-pil-install-args = "Pillow<2"
+
 [versions]
 zc.recipe.egg = 1.2.2
 
@@ -75,7 +77,7 @@ command =
     for i in ${opt:location}/include/j*.h; do ln -fs $i ${:location}/include; done
     for i in ${opt:location}/lib/libjpeg*; do ln -fs $i ${:location}/lib; done
     for i in ${opt:location}/lib/libz*; do ln -fs $i ${:location}/lib; done
-    ${:location}/bin/easy_install ${buildout:pil-install-args}
+    ${:location}/bin/easy_install ${buildout:python24-pil-install-args}
 update-command = ${:command}
 stop-on-error = yes
 

--- a/src/python25.cfg
+++ b/src/python25.cfg
@@ -9,6 +9,8 @@ python25-parts =
     python-2.5-test
 #    python-2.5-buildout
 
+python25-pil-install-args = "Pillow<2"
+
 [python-2.5-build:default]
 recipe = monkeycmmi
 dependencies = ${dependencies:dummy-dependencies}
@@ -69,7 +71,7 @@ command =
     for i in ${opt:location}/include/j*.h; do ln -fs $i ${:location}/include; done
     for i in ${opt:location}/lib/libjpeg*; do ln -fs $i ${:location}/lib; done
     for i in ${opt:location}/lib/libz*; do ln -fs $i ${:location}/lib; done
-    ${:location}/bin/easy_install ${buildout:pil-install-args}
+    ${:location}/bin/easy_install ${buildout:python25-pil-install-args}
 update-command = ${:command}
 stop-on-error = yes
 


### PR DESCRIPTION
Pillow 2.x supports python >= 2.6, for python <=2.5 the Pillow 1.x series needs to be used.

I had to create python version specific `pil-install-args` variables because the default `pil-install-args` is overridden by later loaded python versions (see base.cfg)..
