### PR TITLE
Add *.pyc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ python-3.2
 python-3.3
 bin
 opt
+*.pyc


### PR DESCRIPTION
This is useful if buildout.python is pulled as a git submodule, as this
results in a dirty submodule warning in the main repo.
