### PR TITLE
Enable wide unicode support in Python<3.3

### DIFF
--- a/src/python24.cfg
+++ b/src/python24.cfg
@@ -23,6 +23,7 @@ macosx-opt =
 extra_options =
     ${:macosx-opt}
     --disable-tk
+    --enable-unicode=ucs4
     --prefix=${opt:location}
 
 [python-2.4-build:darwin-leopard]

--- a/src/python25.cfg
+++ b/src/python25.cfg
@@ -18,6 +18,7 @@ executable = ${opt:location}/bin/python2.5
 url = http://www.python.org/ftp/python/2.5.6/Python-2.5.6.tar.bz2
 extra_options =
     --disable-tk
+    --enable-unicode=ucs4
     --prefix=${opt:location}
 
 [python-2.5-build:i386-linux-gnu]

--- a/src/python26.cfg
+++ b/src/python26.cfg
@@ -17,6 +17,7 @@ url = http://www.python.org/ftp/python/2.6.8/Python-2.6.8.tar.bz2
 patch = ${buildout:python-buildout-root}/issue12012-sslv2-py26.txt
 extra_options =
     --disable-tk
+    --enable-unicode=ucs4
     --prefix=${opt:location}
 
 [python-2.6-virtualenv]

--- a/src/python27.cfg
+++ b/src/python27.cfg
@@ -16,6 +16,7 @@ executable = ${opt:location}/bin/python2.7
 url = http://www.python.org/ftp/python/2.7.4/Python-2.7.4.tar.bz2
 extra_options =
     --disable-tk
+    --enable-unicode=ucs4
     --prefix=${opt:location}
 
 [python-2.7-virtualenv]

--- a/src/python32.cfg
+++ b/src/python32.cfg
@@ -14,6 +14,7 @@ executable = ${opt:location}/bin/python3.2
 url = http://www.python.org/ftp/python/3.2.4/Python-3.2.4.tar.bz2
 extra_options =
     --disable-tk
+    --enable-unicode=ucs4
     --prefix=${opt:location}
 
 [python-3.2-virtualenv]

--- a/src/test-python.py
+++ b/src/test-python.py
@@ -10,3 +10,8 @@ def test(options, buildout):
         output = Popen([python, "-c", "import platform; print (platform.mac_ver())"], stdout=PIPE).communicate()[0]
         if not output.startswith("('10."):
             raise IOError("Your python at %s doesn't return proper data for platform.mac_ver(), got: %s" % (python, output))
+
+    p = Popen([python, "-c", "getattr(__builtins__, 'unichr', chr)(120144)"])
+    p.communicate()
+    if p.returncode != 0:
+        raise IOError("Your Python isn't compiled with wide character support")


### PR DESCRIPTION
The python by generated by buildout.python does not support arbitrary characters because it compiles the so-called "narrow" (which should really be called "buggy") version of Python.

Wide builds [are available since cPython 2.2](http://www.python.org/dev/peps/pep-0261/). Narrow builds [have been removed in cPython 3.3](http://docs.python.org/dev/whatsnew/3.3.html#pep-393-flexible-string-representation).

A simple check to see whether the installed Python is buggy is verifying that

```
assert len(u'\U0001d550') == 1
```

in Python 2.x or

```
assert len('\U0001d550') == 1
```

in Python 3.1 and 3.2 does not throw any exceptions. For a version-independent (but not as obvious) test, try

```
getattr(__builtins__, 'unichr', chr)(120144)
```
