### PR TITLE
Update setuptools to 5.4.1 in python3.3 and python3.4

### DIFF
--- a/src/python33.cfg
+++ b/src/python33.cfg
@@ -29,6 +29,7 @@ executable = ${python-3.3-build:executable}
 easy_install = ${opt:location}/bin/easy_install-3.3
 command =
     ${:executable} ${buildout:python-buildout-root}/ez_setup.py
+    ${:easy_install} -U setuptools==5.4.1
     ${:easy_install} -U pip
     ${python-3.3-virtualenv:output} --system-site-packages ${buildout:directory}/python-3.3
 update-command = ${python-3.3:command}

--- a/src/python34.cfg
+++ b/src/python34.cfg
@@ -23,7 +23,7 @@ easy_install = ${opt:location}/bin/easy_install-3.4
 pyvenv = ${opt:location}/bin/pyvenv-3.4
 command =
     ${:executable} ${buildout:python-buildout-root}/ez_setup.py
-    ${:easy_install} -U setuptools==1.3.2
+    ${:easy_install} -U setuptools==5.4.1
     ${:easy_install} -U pip
     ${:pyvenv} --system-site-packages ${buildout:directory}/python-3.4
 update-command = ${python-3.4:command}


### PR DESCRIPTION
Motivation for the update is that current [autobahn](http://autobahn.ws/) requires setuptools >= 2.2.