### PR TITLE
Make platform.mac_ver() return '10.10' on Yosemite.

### DIFF
--- a/src/python-2.4-darwin-10.10.patch
+++ b/src/python-2.4-darwin-10.10.patch
@@ -1,0 +1,51 @@
+diff -ru Lib/platform.py Lib/platform.py
+--- Lib/platform.py	2006-10-08 18:41:25.000000000 +0100
++++ Lib/platform.py	2015-03-11 21:48:12.000000000 +0000
+@@ -31,6 +31,7 @@
+ #      Colin Kong, Trent Mick, Guido van Rossum
+ #
+ #    History:
++#    ?.?.? - backported _mac_ver_xml() from Python 2.7
+ #    1.0.3 - added normalization of Windows system name
+ #    1.0.2 - added more Windows support
+ #    1.0.1 - reformatted to make doc.py happy
+@@ -556,6 +557,26 @@
+ 
+     return hex(bcd)[2:]
+ 
++def _mac_ver_xml():
++    fn = '/System/Library/CoreServices/SystemVersion.plist'
++    if not os.path.exists(fn):
++        return None
++
++    try:
++        import plistlib
++    except ImportError:
++        return None
++
++    pl = plistlib.readPlist(fn)
++    release = pl['ProductVersion']
++    versioninfo=('', '', '')
++    machine = os.uname()[4]
++    if machine in ('ppc', 'Power Macintosh'):
++        # for compatibility with the gestalt based code
++        machine = 'PowerPC'
++
++    return release,versioninfo,machine
++
+ def mac_ver(release='',versioninfo=('','',''),machine=''):
+ 
+     """ Get MacOS version information and return it as tuple (release,
+@@ -572,6 +593,12 @@
+            http://www.rgaros.nl/gestalt/
+ 
+     """
++    # First try reading the information from an XML file which should
++    # always be present
++    info = _mac_ver_xml()
++    if info is not None:
++        return info
++
+     # Check whether the version info module is available
+     try:
+         import gestalt

--- a/src/python24.cfg
+++ b/src/python24.cfg
@@ -67,6 +67,7 @@ environment =
 macosx-opt = MACOSX_DEPLOYMENT_TARGET=10.10
 patches =
     ${buildout:python-buildout-root}/python-2.4-darwin-10.6.patch
+    ${buildout:python-buildout-root}/python-2.4-darwin-10.10.patch
 environment =
     CFLAGS=-arch x86_64
 


### PR DESCRIPTION
Previous wrong behaviour was:

    $ uname -r
    > 14.0.0
    $ buildout.python/python-2.4/bin/python -c 'print __import__("platform").mac_ver()'
    > ('10.9', ('', '', ''), 'x86_64')

New correct behaviour is:

    $ buildout.python/python-2.4/bin/python -c 'print __import__("platform").mac_ver()'
    > ('10.10', ('', '', ''), 'x86_64')

I've backported the _mac_ver_xml() function from Python 2.7 to Python 2.4, which reads /System/Library/CoreServices/SystemVersion.plist to get the current version number instead of using the Gestalt API, because the Gestalt API has a really awesome bug in it wherein it returns 0x1080 on OS X 10.8, 0x1090 on OS X 10.9, and 0x1090 on OS X 10.10.

This bug was manifesting in a buildout failure when I tried to get buildout to build PIL on Yosemite, because bdist_egg in setuptools.command was generating an egg with the name "PIL-1.1.6-py2.4-macosx-10.10-x86_64.egg" (as it gets its idea of OSX's version number from $PREFIX/lib/python2.4/config/Makefile) whereas setuptools.command.easy_install was looking for an egg with the name "PIL-1.1.6-py2.4-macosx-10.9-x86_64.egg" (because it gets its idea of OSX's version number from Gestalt) and subsequently raising an exception like:

    No eggs found in /var/folders/nd/nz2j950x6gd51bjfj2316y580000gr/T/easy_install-gkyUY8/PIL-1.1.6/egg-dist-tmp-Rkpvi3 (setup script problem?)

(Aaaa.)