### PR TITLE
Virtualenv: do not call with --distribute option.

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,6 +4,9 @@ Changes
 2015-03-12
 ----------
 
+- Virtualenv: do not call with --distribute option.
+  [maurits]
+
 - Python2.4: make platform.mac_ver() return '10.10' on Yosemite.
   [RichardBarrell]
 

--- a/src/virtualenv.in
+++ b/src/virtualenv.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-${:executable} ${:virtualenv} --distribute $*
+${:executable} ${:virtualenv} $*


### PR DESCRIPTION
Creating a virtualenv with the --distribute option on Python 2.4 makes
it virtually impossible to upgrade to a newer setuptools, because you
always get the very latest setuptools version, which gives
SyntaxErrors on Python 2.4.

Same may be true for Python 2.5, but I did not test that.

More recent virtualenv versions have deprecated the --distribute
option.  We already use such a version for Python 2.6+.

Upgrading the virtualenv version is not possible for Python 2.4
because 1.7.2 is already the last version that is compatible with
Python 2.4.

Note that it may help to throw away the python-2.4 directory in this
buildout and run the buildout again.  In my local copy I originally
had a distribute egg in python-2.4/lib/python2.4/site-packages.  After
starting over again it was gone and I had an old but nice setuptools
package there, ready for a painless upgrade if I want to.