### PR TITLE
pin collective.recipe.template to be compatible with pinned zc.buildout version

### DIFF
--- a/src/base.cfg
+++ b/src/base.cfg
@@ -15,6 +15,7 @@ pil-install-args = --always-unzip Pillow
 # XXX https://github.com/collective/buildout.python/issues/23
 zc.buildout = 1.4.4
 collective.recipe.cmmi = 0.5
+collective.recipe.template = 1.11
 
 [opt]
 recipe = plone.recipe.command


### PR DESCRIPTION
The recent collective.recipe.template 1.12 release uses a feature from zc.buildout > 1.4.4.

Here's the stack trace for the problem that presents itself:

    While:
      Installing.
      Getting section python-2.7.
      Initializing section python-2.7.
      Getting option python-2.7:update-command.
      Getting option python-2.7:command.
      Getting section python-2.7-virtualenv.
      Initializing part python-2.7-virtualenv.

    An internal error occured due to a bug in either zc.buildout or in a
    recipe being used:
    Traceback (most recent call last):
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1683, in main
        getattr(buildout, command)(args)
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 439, in install
        [self[part]['recipe'] for part in install_parts]
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 987, in __getitem__
        options._initialize()
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1060, in _initialize
        self._dosub(k, v)
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1107, in _dosub
        v = '$$'.join([self._sub(s, seen) for s in v.split('$$')])
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1171, in _sub
        v = self.buildout[section].get(option, None, seen)
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1134, in get
        v = '$$'.join([self._sub(s, seen) for s in v.split('$$')])
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1171, in _sub
        v = self.buildout[section].get(option, None, seen)
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 987, in __getitem__
        options._initialize()
      File "/opt/buildout.python/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1074, in _initialize
        self.recipe = recipe_class(buildout, name, self)
      File "/opt/buildout.python/eggs/collective.recipe.template-1.12-py2.7.egg/collective/recipe/template/__init__.py", line 35, in __init__
        self.overwrite = zc.buildout.buildout.bool_option(options, 'overwrite', True)
    AttributeError: 'module' object has no attribute 'bool_option'