### PR TITLE
Pin setuptools.

### DIFF
--- a/src/base.cfg
+++ b/src/base.cfg
@@ -16,6 +16,7 @@ pil-install-args = --always-unzip Pillow
 zc.buildout = 1.4.4
 collective.recipe.cmmi = 0.5
 collective.recipe.template = 1.11
+setuptools = 1.4.2
 
 [opt]
 recipe = plone.recipe.command


### PR DESCRIPTION
1.4.2 seems a safe version.

Reason to pin it, it so that we at least have some setuptools version
in the generated bin/buildout script.  Without that, you automatically
get whatever setuptools version happens to be in your site packages,
which in my case was setuptools 18, which is incompatible in its error
messages with our old zc.buildout version.

This was the error, on Mac:

mauritsvanrees@procyon:python3.2 (git:master) $ bin/buildout -c local.cfg
/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources/__init__.py:203: RuntimeWarning: You have iterated over the result of pkg_resources.parse_version. This is a legacy behavior which is inconsistent with the new version class introduced in setuptools 8.0. In most cases, conversion to a tuple is unnecessary. For comparison of versions, sort the Version instances directly. If you have another use case requiring the tuple, please file a bug with the setuptools project describing that need.
  stacklevel=1,
While:
  Installing.
  Getting section readline.
  Initializing section readline.
  Installing recipe collective.recipe.cmmi.

An internal error occured due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/Users/mauritsvanrees/buildout/python3.2/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1683, in main
    getattr(buildout, command)(args)
  File "/Users/mauritsvanrees/buildout/python3.2/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 439, in install
    [self[part]['recipe'] for part in install_parts]
  File "/Users/mauritsvanrees/buildout/python3.2/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 987, in __getitem__
    options._initialize()
  File "/Users/mauritsvanrees/buildout/python3.2/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1071, in _initialize
    recipe_class = _install_and_load(reqs, 'zc.buildout', entry, buildout)
  File "/Users/mauritsvanrees/buildout/python3.2/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py", line 1027, in _install_and_load
    allow_hosts=buildout._allow_hosts
  File "/Users/mauritsvanrees/buildout/python3.2/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/easy_install.py", line 800, in install
    return installer.install(specs, working_set)
  File "/Users/mauritsvanrees/buildout/python3.2/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/easy_install.py", line 662, in install
    [requirement] = err
ValueError: too many values to unpack