### PR TITLE
Add `--enable-optimizations` configure flag.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,10 @@ various Python versions with or without the necessary dependencies.
 The default ``buildout.cfg`` configuration is for Mac OS X Leopard, because that's
 what this buildout was initially created for.
 
+The default configuration is optimized for production builds, trading in
+an increase in build time for a faster Python executable. See the
+compilation options sections below on how to change this.
+
 Installation
 ------------
 
@@ -70,3 +74,21 @@ like this::
 
 The ``python-buildout-root`` setting is important, otherwise the whole buildout
 doesn't work.
+
+Compilation Options
+-------------------
+
+If you want to adjust the configuration or compilation options for
+a Python variant, you can do so via your `local.cfg`.
+
+If you are installing Python 3.6, you could for example turn off compile
+time optimizations via the ``extra_options -=``. Or if you are on a newer
+version of Mac OS, you could link against an OpenSSL library installed
+via Homebrew, via the ``environment`` section::
+
+    [python-3.6-build:default]
+    extra_options -=
+        --enable-optimizations
+    environment =
+        LDFLAGS=-L/usr/local/opt/openssl/lib
+        CPPFLAGS=-I/usr/local/opt/openssl/include

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+2016-11-27
+----------
+
+- Add `--enable-optimizations` configure flag.
+  [hannosch]
+
+
 2016-11-22
 ----------
 

--- a/src/python27.cfg
+++ b/src/python27.cfg
@@ -14,6 +14,7 @@ executable = ${opt:location}/bin/python2.7
 url = https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz
 md5sum = 88d61f82e3616a4be952828b3694109d
 extra_options =
+    --enable-optimizations
     --disable-tk
     --prefix=${opt:location}
 

--- a/src/python35.cfg
+++ b/src/python35.cfg
@@ -14,6 +14,7 @@ executable = ${opt:location}/bin/python3.5
 url = https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz
 md5sum = 3fe8434643a78630c61c6464fe2e7e72
 extra_options =
+    --enable-optimizations
     --prefix=${opt:location}
 
 [python-3.5-virtualenv]

--- a/src/python36.cfg
+++ b/src/python36.cfg
@@ -14,6 +14,7 @@ executable = ${opt:location}/bin/python3.6
 url = https://www.python.org/ftp/python/3.6.0/Python-3.6.0b4.tgz
 md5sum = ab3ddd6d00e3946e0eb6fbe6a43656ff
 extra_options =
+    --enable-optimizations
     --prefix=${opt:location}
 
 [python-3.6-virtualenv]


### PR DESCRIPTION
This enables profile guided optimizations (PGO) on supported Python versions. PGO increases build time significantly, but results in Python being faster at runtime.

The configure flag is backported to the 2.7, 3.5 and 3.6 branches, but only available in the last 3.6 release as of yet. Once 2.7.13 and 3.5.3 are released, it will take effect for those as well. See for example http://bugs.python.org/issue26359.

There are a whole bunch of other related issues around LTO (link time optimization), but so far LTO is considered to be too unstable by the Python developers to be enabled with the new flag.

One can always remove this setting via ``extra_options -= --enable-optimizations`` or overwriting all of ``extra_options``. Right now adding the flag for 2.7/3.5 results in a harmless configure warning. But I'd rather add the flag now before I forget about it again ;)

@mjpieters, @fschulze Thoughts?