### PR TITLE
Downgrading readline from 6.3 to 6.2, because that gives me working r…

### DIFF
--- a/src/readline.cfg
+++ b/src/readline.cfg
@@ -9,7 +9,7 @@ dummy-readline = ${readline:recipe}
 
 [readline:default]
 recipe = collective.recipe.cmmi
-url = https://ftp.gnu.org/gnu/readline/readline-6.3.tar.gz
+url = https://ftp.gnu.org/gnu/readline/readline-6.2.tar.gz
 extra_options =
     --prefix=${opt:location}
 


### PR DESCRIPTION
…eadline on ubuntu 16.04

As the title says - when running the buildout on a ubuntu 16.04, I get only python in which readline isn't working. See https://baach.de/Members/jhb/installing-python-buildout-with-readline.

So maybe downgrading to readline 6.2 is a solution?
