### PR TITLE
Pin setuptools to <36.1.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,6 +1,15 @@
 Changes
 =======
 
+2017-07-28
+----------
+
+- Pin setuptools to <36.1. Upgrading further causes Pillow to fail to install.
+  This may be caused by the inability of setuptools to install/upgrade itself
+  anymore.
+  [fschulze]
+
+
 2017-07-18
 ----------
 

--- a/src/python33.cfg
+++ b/src/python33.cfg
@@ -38,7 +38,7 @@ executable = ${python-3.3-build:executable}
 easy_install = ${opt:location}/bin/easy_install-3.3
 command =
     ${:executable} ${buildout:python-buildout-root}/ez_setup-latest.py
-    ${:easy_install} -U setuptools
+    ${:easy_install} -U "setuptools<36.1"
     ${:easy_install} -U pip
     ${python-3.3-virtualenv:output} --system-site-packages ${buildout:directory}/python-3.3
 update-command = ${python-3.3:command}

--- a/src/python34.cfg
+++ b/src/python34.cfg
@@ -38,7 +38,7 @@ executable = ${python-3.4-build:executable}
 easy_install = ${opt:location}/bin/easy_install-3.4
 command =
     ${:executable} ${buildout:python-buildout-root}/ez_setup-latest.py
-    ${:easy_install} -U setuptools
+    ${:easy_install} -U "setuptools<36.1"
     ${:easy_install} -U pip
     ${python-3.4-virtualenv:output} --system-site-packages ${buildout:directory}/python-3.4
 update-command = ${python-3.4:command}

--- a/src/python35.cfg
+++ b/src/python35.cfg
@@ -40,7 +40,7 @@ easy_install = ${opt:location}/bin/easy_install-3.5
 pyvenv = ${opt:location}/bin/pyvenv-3.5
 command =
     ${:executable} ${buildout:python-buildout-root}/ez_setup-latest.py
-    ${:easy_install} -U setuptools
+    ${:easy_install} -U "setuptools<36.1"
     ${:easy_install} -U pip
     ${python-3.5-virtualenv:output} --system-site-packages ${buildout:directory}/python-3.5
 update-command = ${python-3.5:command}

--- a/src/python36.cfg
+++ b/src/python36.cfg
@@ -40,7 +40,7 @@ easy_install = ${opt:location}/bin/easy_install-3.6
 pyvenv = ${opt:location}/bin/pyvenv-3.6
 command =
     ${:executable} ${buildout:python-buildout-root}/ez_setup-latest.py
-    ${:easy_install} -U setuptools
+    ${:easy_install} -U "setuptools<36.1"
     ${:easy_install} -U pip
     ${python-3.6-virtualenv:output} --system-site-packages ${buildout:directory}/python-3.6
 update-command = ${python-3.6:command}


### PR DESCRIPTION
Upgrading further causes Pillow to fail to install. This may be caused by the inability of setuptools to install/upgrade itself anymore.