### PR TITLE
Add travis tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ opt
 *.pyc
 setuptools*.tar.gz
 setuptools*.zip
+test.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: generic
+sudo: false
+env:
+  matrix:
+    - BUILDOUT_TARGET=python24 EXECUTABLE=python-2.4/bin/python
+    - BUILDOUT_TARGET=python25 EXECUTABLE=python-2.5/bin/python
+    - BUILDOUT_TARGET=python26 EXECUTABLE=python-2.6/bin/python
+    - BUILDOUT_TARGET=python27 EXECUTABLE=python-2.7/bin/python
+    - BUILDOUT_TARGET=python32 EXECUTABLE=python-3.2/bin/python
+    - BUILDOUT_TARGET=python33 EXECUTABLE=python-3.3/bin/python
+    - BUILDOUT_TARGET=python34 EXECUTABLE=python-3.4/bin/python
+    - BUILDOUT_TARGET=python35 EXECUTABLE=python-3.5/bin/python
+    - BUILDOUT_TARGET=python36 EXECUTABLE=python-3.6/bin/python
+    - BUILDOUT_TARGET=python37 EXECUTABLE=python-3.7/bin/python
+    - BUILDOUT_TARGET=pypy EXECUTABLE=pypy/bin/python
+    - BUILDOUT_TARGET=pypy3 EXECUTABLE=pypy3/bin/python
+os:
+  - linux
+  - osx
+script:
+  - make -f make-tests buildout_target=$BUILDOUT_TARGET
+  - $EXECUTABLE -V

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+2018-01-26
+----------
+
+- Add Travis-CI testing.
+  [fschulze]
+
+
 2018-01-10
 ----------
 

--- a/make-tests
+++ b/make-tests
@@ -1,0 +1,24 @@
+define cfg
+[buildout]
+extends =
+    src/base.cfg
+    src/readline.cfg
+    src/$(buildout_target).cfg
+python-buildout-root = $${buildout:directory}/src
+parts =
+    $${buildout:base-parts}
+    $${buildout:readline-parts}
+    $${buildout:$(buildout_target)-parts}
+endef
+export cfg
+
+all: .installed.cfg
+
+test.cfg:
+	test -e $@ || echo "$$cfg" > $@
+
+bin/buildout:
+	python bootstrap.py
+
+.installed.cfg: test.cfg bin/buildout
+	bin/buildout -vc test.cfg


### PR DESCRIPTION
Currently this exposes existing issues with Python 2.4 on Linux (which also exist in High Sierra, which Travis doesn't support yet) and PyPy on OS X (known by the PyPy devs, basically one needs to install some stuff with homebrew).

I would have just merged this change, but I can't activate Travis in the collective repository.