### PR TITLE
Add zlib.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ like this::
     extends =
       src/base.cfg
       src/readline.cfg
+      src/zlib.cfg
       src/python25.cfg
       src/links.cfg
 
@@ -67,6 +68,7 @@ like this::
     parts =
         ${buildout:base-parts}
         ${buildout:readline-parts}
+        ${buildout:zlib-parts}
         ${buildout:python25-parts}
         ${buildout:links-parts}
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,6 +3,7 @@
 extends =
     src/base.cfg
     src/readline.cfg
+    src/zlib.cfg
     src/python24.cfg
     src/python25.cfg
     src/python26.cfg
@@ -20,6 +21,7 @@ extends =
 parts =
     ${buildout:base-parts}
     ${buildout:readline-parts}
+    ${buildout:zlib-parts}
     ${buildout:python24-parts}
     ${buildout:python25-parts}
     ${buildout:python26-parts}

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,10 @@ Changes
 2018-01-26
 ----------
 
+- Add zlib to the build, so Python 2.4 compiles on Linux and compilation of
+  Python on High Sierra works properly.
+  [fschulze]
+
 - Add Travis-CI testing.
   [fschulze]
 

--- a/make-tests
+++ b/make-tests
@@ -3,11 +3,13 @@ define cfg
 extends =
     src/base.cfg
     src/readline.cfg
+    src/zlib.cfg
     src/$(buildout_target).cfg
 python-buildout-root = $${buildout:directory}/src
 parts =
     $${buildout:base-parts}
     $${buildout:readline-parts}
+    $${buildout:zlib-parts}
     $${buildout:$(buildout_target)-parts}
 endef
 export cfg

--- a/src/zlib.cfg
+++ b/src/zlib.cfg
@@ -1,0 +1,46 @@
+[buildout]
+extends = base.cfg
+parts = ${buildout:zlib-parts}
+zlib-parts =
+    zlib
+
+[dependencies]
+dummy-zlib = ${zlib:recipe}
+
+[zlib:default]
+recipe = collective.recipe.cmmi
+url = https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.gz
+md5sum = 1c9f62f0778697a09d36121ead88e08e
+extra_options =
+    --prefix=${opt:location}
+
+[zlib:darwin-snowleopard-64]
+<= zlib:default
+environment =
+    CFLAGS=-arch x86_64
+
+[zlib:darwin-lion]
+<= zlib:darwin-snowleopard-64
+
+[zlib:darwin-mountainlion]
+<= zlib:darwin-lion
+
+[zlib:darwin-mavericks]
+<= zlib:darwin-mountainlion
+
+[zlib:darwin-yosemite]
+<= zlib:darwin-mavericks
+
+[zlib:darwin-elcapitan]
+<= zlib:darwin-yosemite
+
+[zlib:darwin-sierra]
+<= zlib:darwin-elcapitan
+
+[zlib:darwin-highsierra]
+<= zlib:darwin-sierra
+
+[zlib:x86_64]
+<= zlib:default
+environment =
+    CFLAGS=-fPIC


### PR DESCRIPTION
Add zlib to the build, so Python 2.4 compiles on Linux and compilation of Python on High Sierra works properly.

Can anyone confirm that this is required for macOS High Sierra? Maybe it's just on my box. Homebrew doesn't link zlib into /usr/local anymore, because macOS provides it's own zlib, but that one isn't picked up by ``configure``.

As one can see, it fixes compilation of Python 2.4 on Linux (see https://travis-ci.org/collective/buildout.python/builds/333668504) and compare to this PRs results.