### PR TITLE
On Mac Mojave, add CFLAGS so we can find zlib.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+2019-04-30
+----------
+
+- On Mac Mojave, add CFLAGS=-I$(xcrun --show-sdk-path)/usr/include so we can find zlib.
+  [maurits]
+
 2019-03-29
 ----------
 

--- a/src/python35.cfg
+++ b/src/python35.cfg
@@ -33,6 +33,9 @@ extra_options =
     --enable-optimizations
     --prefix=${opt:location}
     --with-openssl=/usr/local/opt/openssl@1.1
+environment =
+# Include `xcrun --show-sdk-path` to find zlib.
+    CFLAGS=-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include
 
 [python-3.5-virtualenv]
 recipe = collective.recipe.template

--- a/src/python36.cfg
+++ b/src/python36.cfg
@@ -33,6 +33,9 @@ extra_options =
     --enable-optimizations
     --prefix=${opt:location}
     --with-openssl=/usr/local/opt/openssl@1.1
+environment =
+# Include `xcrun --show-sdk-path` to find zlib.
+    CFLAGS=-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include
 
 [python-3.6-virtualenv]
 recipe = collective.recipe.template

--- a/src/python37.cfg
+++ b/src/python37.cfg
@@ -33,6 +33,13 @@ extra_options =
     --enable-optimizations
     --prefix=${opt:location}
     --with-openssl=/usr/local/opt/openssl@1.1
+# Set CFLAGS to find zlib.
+# https://stackoverflow.com/questions/52741673/how-can-i-install-zlib-on-mac-os-x-mojave-10-14/52756409#52756409
+# https://github.com/pyenv/pyenv/issues/1219
+environment =
+# This would be nice, but Maurits can't get it running:
+#    CFLAGS=-I$(xcrun --show-sdk-path)/usr/include
+    CFLAGS=-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include
 
 [python-3.7-virtualenv]
 recipe = collective.recipe.template


### PR DESCRIPTION
On Mac Mojave, add CFLAGS to to the environment.
I would have liked to add `I$(xcrun --show-sdk-path)/usr/include` but I could not get this to work in buildout.
So I included the result of that `xcrun` command literally:


```
CFLAGS=-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include
```

Without the CFLAGS, I get an error, for example building Python 3.5:

```
rm -f /usr/local/py35/parts/opt/bin/pyvenv
(cd /usr/local/py35/parts/opt/bin; ln -s pyvenv-3.5 pyvenv)
if test x != x ; then  rm -f /usr/local/py35/parts/opt/bin/python3-32;  (cd /usr/local/py35/parts/opt/bin; ln -s python3.5-32 python3-32)  fi
rm -f /usr/local/py35/parts/opt/share/man/man1/python3.1
(cd /usr/local/py35/parts/opt/share/man/man1; ln -s python3.5.1 python3.1)
if test xupgrade != xno  ; then  case upgrade in  upgrade) ensurepip=--upgrade ;;  install|*) ensurepip= ;;  esac;   ./python.exe -E -m ensurepip   --root=/ ;  fi
Traceback (most recent call last):
  File /private/var/folders/g1/3lr2tj2d1vn80qb686lcbrbm0000gp/T/tmpLQR1RPbuildout-python-3.5-build/Python-3.5.7/Lib/runpy.py, line 193, in _run_module_as_main
    __main__, mod_spec)
  File /private/var/folders/g1/3lr2tj2d1vn80qb686lcbrbm0000gp/T/tmpLQR1RPbuildout-python-3.5-build/Python-3.5.7/Lib/runpy.py, line 85, in _run_code
    exec(code, run_globals)
  File /private/var/folders/g1/3lr2tj2d1vn80qb686lcbrbm0000gp/T/tmpLQR1RPbuildout-python-3.5-build/Python-3.5.7/Lib/ensurepip/__main__.py, line 4, in <module>
    ensurepip._main()
  File /private/var/folders/g1/3lr2tj2d1vn80qb686lcbrbm0000gp/T/tmpLQR1RPbuildout-python-3.5-build/Python-3.5.7/Lib/ensurepip/__init__.py, line 209, in _main
    default_pip=args.default_pip,
  File /private/var/folders/g1/3lr2tj2d1vn80qb686lcbrbm0000gp/T/tmpLQR1RPbuildout-python-3.5-build/Python-3.5.7/Lib/ensurepip/__init__.py, line 116, in bootstrap
    _run_pip(args + [p[0] for p in _PROJECTS], additional_paths)
  File /private/var/folders/g1/3lr2tj2d1vn80qb686lcbrbm0000gp/T/tmpLQR1RPbuildout-python-3.5-build/Python-3.5.7/Lib/ensurepip/__init__.py, line 40, in _run_pip
    import pip
zipimport.ZipImportError: can't decompress data; zlib not available
make: *** [install] Error 1
python-3.5-build: cmmi failed: /var/folders/g1/3lr2tj2d1vn80qb686lcbrbm0000gp/T/tmpLQR1RPbuildout-python-3.5-build
While:
  Installing python-3.5-build.
An internal error occured due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File /usr/local/py35/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py, line 1683, in main
    getattr(buildout, command)(args)
  File /usr/local/py35/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py, line 555, in install
    installed_files = self[part]._call(recipe.install)
  File /usr/local/py35/eggs/zc.buildout-1.4.4-py2.7.egg/zc/buildout/buildout.py, line 1227, in _call
    return f()
  File build/bdist.macosx-10.14-intel/egg/zc/recipe/cmmi/__init__.py, line 113, in install
    self.build()
  File /usr/local/py35/eggs/collective.recipe.cmmi-0.5-py2.7.egg/collective/recipe/cmmi/__init__.py, line 24, in build
    result = Base.build(self)
  File build/bdist.macosx-10.14-intel/egg/zc/recipe/cmmi/__init__.py, line 196, in build
    self.cmmi(dest)
  File /usr/local/py35/eggs/collective.recipe.cmmi-0.5-py2.7.egg/collective/recipe/cmmi/__init__.py, line 62, in cmmi
    system(%s %s install % (make, make_options))
  File build/bdist.macosx-10.14-intel/egg/zc/recipe/cmmi/__init__.py, line 34, in system
    raise SystemError(Failed, c)
SystemError: ('Failed', 'make  install')
```

Same for Python 3.6 and 3.7.
Not on Python 2.7, pypym pypy3.
Not tested on older Python 2 and 3 versions.

See also:
https://stackoverflow.com/questions/48288658/zipimport-zipimporterror-cant-decompress-data-zlib-not-available#50370494
and:
https://stackoverflow.com/questions/52741673/how-can-i-install-zlib-on-mac-os-x-mojave-10-14/52756409#52756409
which points to `pyenv` having the same issue, and a solution in the works:
https://github.com/pyenv/pyenv/issues/1219