### PR TITLE
Backport MacOS 10.14 SDK handling to 3.2-3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,23 +46,6 @@ jobs:
             target: python32
             xfail: true
 
-          # additional backports needed for macOS 10.14 SDK changes
-          - os: macos-latest
-            target: python32
-            xfail: true
-          - os: macos-latest
-            target: python33
-            xfail: true
-          - os: macos-latest
-            target: python34
-            xfail: true
-          - os: macos-latest
-            target: python35
-            xfail: true
-          - os: macos-latest
-            target: python36
-            xfail: true
-
     continue-on-error: ${{ matrix.xfail || false }}
     runs-on: ${{ matrix.os }}
     env:

--- a/src/python-3.2-darwin-10.14.patch
+++ b/src/python-3.2-darwin-10.14.patch
@@ -1,5 +1,5 @@
 diff --git setup.py setup.py
-index bddb675072..72a83b0532 100644
+index bddb675072..7763ebe062 100644
 --- setup.py
 +++ setup.py
 @@ -42,18 +42,57 @@ def add_dir_to_list(dirlist, dir):
@@ -68,3 +68,12 @@ index bddb675072..72a83b0532 100644
  
  def is_macosx_sdk_path(path):
      """
+@@ -1235,6 +1274,8 @@ class PyBuildExt(build_ext):
+             zlib_h = zlib_inc[0] + '/zlib.h'
+             version = '"0.0.0"'
+             version_req = '"1.1.3"'
++            if sys.platform == 'darwin' and is_macosx_sdk_path(zlib_h):
++                zlib_h = os.path.join(macosx_sdk_root(), zlib_h[1:])
+             with open(zlib_h) as fp:
+                 while 1:
+                     line = fp.readline()

--- a/src/python-3.2-darwin-10.14.patch
+++ b/src/python-3.2-darwin-10.14.patch
@@ -1,0 +1,70 @@
+diff --git setup.py setup.py
+index bddb675072..72a83b0532 100644
+--- setup.py
++++ setup.py
+@@ -42,18 +42,57 @@ def add_dir_to_list(dirlist, dir):
+             return
+     dirlist.insert(0, dir)
+ 
++MACOS_SDK_ROOT = None
++
+ def macosx_sdk_root():
++    """Return the directory of the current macOS SDK.
++
++    If no SDK was explicitly configured, call the compiler to find which
++    include files paths are being searched by default.  Use '/' if the
++    compiler is searching /usr/include (meaning system header files are
++    installed) or use the root of an SDK if that is being searched.
++    (The SDK may be supplied via Xcode or via the Command Line Tools).
++    The SDK paths used by Apple-supplied tool chains depend on the
++    setting of various variables; see the xcrun man page for more info.
+     """
+-    Return the directory of the current OSX SDK,
+-    or '/' if no SDK was specified.
+-    """
++    global MACOS_SDK_ROOT
++
++    # If already called, return cached result.
++    if MACOS_SDK_ROOT:
++        return MACOS_SDK_ROOT
++
+     cflags = sysconfig.get_config_var('CFLAGS')
+-    m = re.search(r'-isysroot\s+(\S+)', cflags)
+-    if m is None:
+-        sysroot = '/'
++    m = re.search(r'-isysroot\s*(\S+)', cflags)
++    if m is not None:
++        MACOS_SDK_ROOT = m.group(1)
+     else:
+-        sysroot = m.group(1)
+-    return sysroot
++        MACOS_SDK_ROOT = '/'
++        cc = sysconfig.get_config_var('CC')
++        tmpfile = '/tmp/setup_sdk_root.%d' % os.getpid()
++        try:
++            os.unlink(tmpfile)
++        except:
++            pass
++        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
++        in_incdirs = False
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    for line in fp.readlines():
++                        if line.startswith("#include <...>"):
++                            in_incdirs = True
++                        elif line.startswith("End of search list"):
++                            in_incdirs = False
++                        elif in_incdirs:
++                            line = line.strip()
++                            if line == '/usr/include':
++                                MACOS_SDK_ROOT = '/'
++                            elif line.endswith(".sdk/usr/include"):
++                                MACOS_SDK_ROOT = line[:-12]
++        finally:
++            os.unlink(tmpfile)
++
++    return MACOS_SDK_ROOT
+ 
+ def is_macosx_sdk_path(path):
+     """

--- a/src/python-3.3-darwin-10.14.patch
+++ b/src/python-3.3-darwin-10.14.patch
@@ -1,0 +1,70 @@
+diff --git setup.py setup.py
+index 3438b639f6..ae7932f505 100644
+--- setup.py
++++ setup.py
+@@ -48,18 +48,57 @@ def add_dir_to_list(dirlist, dir):
+             return
+     dirlist.insert(0, dir)
+ 
++MACOS_SDK_ROOT = None
++
+ def macosx_sdk_root():
++    """Return the directory of the current macOS SDK.
++
++    If no SDK was explicitly configured, call the compiler to find which
++    include files paths are being searched by default.  Use '/' if the
++    compiler is searching /usr/include (meaning system header files are
++    installed) or use the root of an SDK if that is being searched.
++    (The SDK may be supplied via Xcode or via the Command Line Tools).
++    The SDK paths used by Apple-supplied tool chains depend on the
++    setting of various variables; see the xcrun man page for more info.
+     """
+-    Return the directory of the current OSX SDK,
+-    or '/' if no SDK was specified.
+-    """
++    global MACOS_SDK_ROOT
++
++    # If already called, return cached result.
++    if MACOS_SDK_ROOT:
++        return MACOS_SDK_ROOT
++
+     cflags = sysconfig.get_config_var('CFLAGS')
+-    m = re.search(r'-isysroot\s+(\S+)', cflags)
+-    if m is None:
+-        sysroot = '/'
++    m = re.search(r'-isysroot\s*(\S+)', cflags)
++    if m is not None:
++        MACOS_SDK_ROOT = m.group(1)
+     else:
+-        sysroot = m.group(1)
+-    return sysroot
++        MACOS_SDK_ROOT = '/'
++        cc = sysconfig.get_config_var('CC')
++        tmpfile = '/tmp/setup_sdk_root.%d' % os.getpid()
++        try:
++            os.unlink(tmpfile)
++        except:
++            pass
++        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
++        in_incdirs = False
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    for line in fp.readlines():
++                        if line.startswith("#include <...>"):
++                            in_incdirs = True
++                        elif line.startswith("End of search list"):
++                            in_incdirs = False
++                        elif in_incdirs:
++                            line = line.strip()
++                            if line == '/usr/include':
++                                MACOS_SDK_ROOT = '/'
++                            elif line.endswith(".sdk/usr/include"):
++                                MACOS_SDK_ROOT = line[:-12]
++        finally:
++            os.unlink(tmpfile)
++
++    return MACOS_SDK_ROOT
+ 
+ def is_macosx_sdk_path(path):
+     """

--- a/src/python-3.4-darwin-10.14.patch
+++ b/src/python-3.4-darwin-10.14.patch
@@ -1,0 +1,70 @@
+diff --git setup.py setup.py
+index 88c3759d09..db1052d3f9 100644
+--- setup.py
++++ setup.py
+@@ -56,18 +56,57 @@ def add_dir_to_list(dirlist, dir):
+             return
+     dirlist.insert(0, dir)
+ 
++MACOS_SDK_ROOT = None
++
+ def macosx_sdk_root():
++    """Return the directory of the current macOS SDK.
++
++    If no SDK was explicitly configured, call the compiler to find which
++    include files paths are being searched by default.  Use '/' if the
++    compiler is searching /usr/include (meaning system header files are
++    installed) or use the root of an SDK if that is being searched.
++    (The SDK may be supplied via Xcode or via the Command Line Tools).
++    The SDK paths used by Apple-supplied tool chains depend on the
++    setting of various variables; see the xcrun man page for more info.
+     """
+-    Return the directory of the current OSX SDK,
+-    or '/' if no SDK was specified.
+-    """
++    global MACOS_SDK_ROOT
++
++    # If already called, return cached result.
++    if MACOS_SDK_ROOT:
++        return MACOS_SDK_ROOT
++
+     cflags = sysconfig.get_config_var('CFLAGS')
+-    m = re.search(r'-isysroot\s+(\S+)', cflags)
+-    if m is None:
+-        sysroot = '/'
++    m = re.search(r'-isysroot\s*(\S+)', cflags)
++    if m is not None:
++        MACOS_SDK_ROOT = m.group(1)
+     else:
+-        sysroot = m.group(1)
+-    return sysroot
++        MACOS_SDK_ROOT = '/'
++        cc = sysconfig.get_config_var('CC')
++        tmpfile = '/tmp/setup_sdk_root.%d' % os.getpid()
++        try:
++            os.unlink(tmpfile)
++        except:
++            pass
++        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
++        in_incdirs = False
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    for line in fp.readlines():
++                        if line.startswith("#include <...>"):
++                            in_incdirs = True
++                        elif line.startswith("End of search list"):
++                            in_incdirs = False
++                        elif in_incdirs:
++                            line = line.strip()
++                            if line == '/usr/include':
++                                MACOS_SDK_ROOT = '/'
++                            elif line.endswith(".sdk/usr/include"):
++                                MACOS_SDK_ROOT = line[:-12]
++        finally:
++            os.unlink(tmpfile)
++
++    return MACOS_SDK_ROOT
+ 
+ def is_macosx_sdk_path(path):
+     """

--- a/src/python-3.5-darwin-10.14.patch
+++ b/src/python-3.5-darwin-10.14.patch
@@ -1,0 +1,70 @@
+diff --git setup.py setup.py
+index 2944c9dd6f..02a1499d57 100644
+--- setup.py
++++ setup.py
+@@ -60,18 +60,57 @@ def add_dir_to_list(dirlist, dir):
+             return
+     dirlist.insert(0, dir)
+ 
++MACOS_SDK_ROOT = None
++
+ def macosx_sdk_root():
++    """Return the directory of the current macOS SDK.
++
++    If no SDK was explicitly configured, call the compiler to find which
++    include files paths are being searched by default.  Use '/' if the
++    compiler is searching /usr/include (meaning system header files are
++    installed) or use the root of an SDK if that is being searched.
++    (The SDK may be supplied via Xcode or via the Command Line Tools).
++    The SDK paths used by Apple-supplied tool chains depend on the
++    setting of various variables; see the xcrun man page for more info.
+     """
+-    Return the directory of the current OSX SDK,
+-    or '/' if no SDK was specified.
+-    """
++    global MACOS_SDK_ROOT
++
++    # If already called, return cached result.
++    if MACOS_SDK_ROOT:
++        return MACOS_SDK_ROOT
++
+     cflags = sysconfig.get_config_var('CFLAGS')
+-    m = re.search(r'-isysroot\s+(\S+)', cflags)
+-    if m is None:
+-        sysroot = '/'
++    m = re.search(r'-isysroot\s*(\S+)', cflags)
++    if m is not None:
++        MACOS_SDK_ROOT = m.group(1)
+     else:
+-        sysroot = m.group(1)
+-    return sysroot
++        MACOS_SDK_ROOT = '/'
++        cc = sysconfig.get_config_var('CC')
++        tmpfile = '/tmp/setup_sdk_root.%d' % os.getpid()
++        try:
++            os.unlink(tmpfile)
++        except:
++            pass
++        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
++        in_incdirs = False
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    for line in fp.readlines():
++                        if line.startswith("#include <...>"):
++                            in_incdirs = True
++                        elif line.startswith("End of search list"):
++                            in_incdirs = False
++                        elif in_incdirs:
++                            line = line.strip()
++                            if line == '/usr/include':
++                                MACOS_SDK_ROOT = '/'
++                            elif line.endswith(".sdk/usr/include"):
++                                MACOS_SDK_ROOT = line[:-12]
++        finally:
++            os.unlink(tmpfile)
++
++    return MACOS_SDK_ROOT
+ 
+ def is_macosx_sdk_path(path):
+     """

--- a/src/python-3.6-darwin-10.14.patch
+++ b/src/python-3.6-darwin-10.14.patch
@@ -1,0 +1,70 @@
+diff --git setup.py setup.py
+index e2c1898253..55f9dc5b57 100644
+--- setup.py
++++ setup.py
+@@ -90,18 +90,57 @@ def sysroot_paths(make_vars, subdirs):
+                 break
+     return dirs
+ 
++MACOS_SDK_ROOT = None
++
+ def macosx_sdk_root():
++    """Return the directory of the current macOS SDK.
++
++    If no SDK was explicitly configured, call the compiler to find which
++    include files paths are being searched by default.  Use '/' if the
++    compiler is searching /usr/include (meaning system header files are
++    installed) or use the root of an SDK if that is being searched.
++    (The SDK may be supplied via Xcode or via the Command Line Tools).
++    The SDK paths used by Apple-supplied tool chains depend on the
++    setting of various variables; see the xcrun man page for more info.
+     """
+-    Return the directory of the current OSX SDK,
+-    or '/' if no SDK was specified.
+-    """
++    global MACOS_SDK_ROOT
++
++    # If already called, return cached result.
++    if MACOS_SDK_ROOT:
++        return MACOS_SDK_ROOT
++
+     cflags = sysconfig.get_config_var('CFLAGS')
+-    m = re.search(r'-isysroot\s+(\S+)', cflags)
+-    if m is None:
+-        sysroot = '/'
++    m = re.search(r'-isysroot\s*(\S+)', cflags)
++    if m is not None:
++        MACOS_SDK_ROOT = m.group(1)
+     else:
+-        sysroot = m.group(1)
+-    return sysroot
++        MACOS_SDK_ROOT = '/'
++        cc = sysconfig.get_config_var('CC')
++        tmpfile = '/tmp/setup_sdk_root.%d' % os.getpid()
++        try:
++            os.unlink(tmpfile)
++        except:
++            pass
++        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
++        in_incdirs = False
++        try:
++            if ret >> 8 == 0:
++                with open(tmpfile) as fp:
++                    for line in fp.readlines():
++                        if line.startswith("#include <...>"):
++                            in_incdirs = True
++                        elif line.startswith("End of search list"):
++                            in_incdirs = False
++                        elif in_incdirs:
++                            line = line.strip()
++                            if line == '/usr/include':
++                                MACOS_SDK_ROOT = '/'
++                            elif line.endswith(".sdk/usr/include"):
++                                MACOS_SDK_ROOT = line[:-12]
++        finally:
++            os.unlink(tmpfile)
++
++    return MACOS_SDK_ROOT
+ 
+ def is_macosx_sdk_path(path):
+     """

--- a/src/python32.cfg
+++ b/src/python32.cfg
@@ -34,6 +34,8 @@ environment =
 
 [python-3.2-build:darwin-mojave]
 <= python-3.2-build:darwin-highsierra
+patches =
+    ${buildout:python-buildout-root}/python-3.2-darwin-10.14.patch
 plat_options =
     --with-openssl=/usr/local/opt/openssl@1.0
 

--- a/src/python33.cfg
+++ b/src/python33.cfg
@@ -33,6 +33,8 @@ environment =
 
 [python-3.3-build:darwin-mojave]
 <= python-3.3-build:darwin-highsierra
+patches =
+    ${buildout:python-buildout-root}/python-3.4-darwin-10.14.patch
 plat_options =
     --with-openssl=/usr/local/opt/openssl@1.0
 

--- a/src/python34.cfg
+++ b/src/python34.cfg
@@ -33,6 +33,8 @@ environment =
 
 [python-3.4-build:darwin-mojave]
 <= python-3.4-build:darwin-highsierra
+patches =
+    ${buildout:python-buildout-root}/python-3.4-darwin-10.14.patch
 plat_options =
     --with-openssl=/usr/local/opt/openssl@1.0
 

--- a/src/python35.cfg
+++ b/src/python35.cfg
@@ -34,6 +34,8 @@ environment =
 
 [python-3.5-build:darwin-mojave]
 <= python-3.5-build:darwin-highsierra
+patches =
+    ${buildout:python-buildout-root}/python-3.5-darwin-10.14.patch
 plat_options =
     --with-openssl=/usr/local/opt/openssl@1.1
 

--- a/src/python36.cfg
+++ b/src/python36.cfg
@@ -34,6 +34,8 @@ environment =
 
 [python-3.6-build:darwin-mojave]
 <= python-3.6-build:darwin-highsierra
+patches =
+    ${buildout:python-buildout-root}/python-3.6-darwin-10.14.patch
 plat_options =
     --with-openssl=/usr/local/opt/openssl@1.1
 


### PR DESCRIPTION
This ensures that these older versions still build on OS X.