### PR TITLE
Ensure that readline and openssl work on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu-')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev libbz2-dev libsqlite3-dev
+          sudo apt-get install -y libssl-dev libbz2-dev libsqlite3-dev libtinfo-dev
 
       - name: Check out source code
         uses: actions/checkout@v2

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -20,7 +20,7 @@ libssl, python and curl.
 On Debian and Ubuntu GNU/Linux, install the following packages::
 
   $ sudo apt-get install build-essential libssl-dev python curl libbz2-dev
-  libsqlite3-dev
+  libsqlite3-dev libtinfo-dev
 
 For sqlite support on Python 2.4 install the following package::
 

--- a/src/python24.cfg
+++ b/src/python24.cfg
@@ -28,6 +28,11 @@ environment =
     ${:plat_environment}
     ${python-build-openssl10:environment}
 
+[python-2.4-build:linux2]
+<= python-2.4-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}:${openssl10:location}
+
 [python-2.4-build:darwin-leopard]
 <= python-2.4-build:default
 plat_options = MACOSX_DEPLOYMENT_TARGET=10.5

--- a/src/python25.cfg
+++ b/src/python25.cfg
@@ -30,6 +30,11 @@ environment =
     ${:plat_environment}
     ${python-build-openssl10:environment}
 
+[python-2.5-build:linux2]
+<= python-2.5-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}:${openssl10:location}
+
 [python-2.5-build:darwin]
 <= python-2.5-build:default
 patches =

--- a/src/python26.cfg
+++ b/src/python26.cfg
@@ -25,6 +25,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-2.6-build:linux2]
+<= python-2.6-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-2.6-build:darwin]
 <= python-2.6-build:default
 patches =

--- a/src/python27.cfg
+++ b/src/python27.cfg
@@ -24,6 +24,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-2.7-build:linux2]
+<= python-2.7-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-2.7-build:darwin-elcapitan]
 <= python-2.7-build:default
 

--- a/src/python32.cfg
+++ b/src/python32.cfg
@@ -23,6 +23,11 @@ environment =
     ${:plat_environment}
     ${python-build-openssl10:environment}
 
+[python-3.2-build:linux2]
+<= python-3.2-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}:${openssl10:location}
+
 [python-3.2-build:darwin-elcapitan]
 <= python-3.2-build:default
 

--- a/src/python33.cfg
+++ b/src/python33.cfg
@@ -22,6 +22,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-3.3-build:linux2]
+<= python-3.3-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-3.3-build:darwin-elcapitan]
 <= python-3.3-build:default
 

--- a/src/python34.cfg
+++ b/src/python34.cfg
@@ -22,6 +22,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-3.4-build:linux2]
+<= python-3.4-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-3.4-build:darwin-elcapitan]
 <= python-3.4-build:default
 

--- a/src/python35.cfg
+++ b/src/python35.cfg
@@ -23,6 +23,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-3.5-build:linux2]
+<= python-3.5-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-3.5-build:darwin-elcapitan]
 <= python-3.5-build:default
 

--- a/src/python36.cfg
+++ b/src/python36.cfg
@@ -23,6 +23,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-3.6-build:linux2]
+<= python-3.6-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-3.6-build:darwin-elcapitan]
 <= python-3.6-build:default
 

--- a/src/python37.cfg
+++ b/src/python37.cfg
@@ -23,6 +23,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-3.7-build:linux2]
+<= python-3.7-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-3.7-build:darwin-elcapitan]
 <= python-3.7-build:default
 

--- a/src/python38.cfg
+++ b/src/python38.cfg
@@ -23,6 +23,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-3.8-build:linux2]
+<= python-3.8-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-3.8-build:darwin-elcapitan]
 <= python-3.8-build:default
 

--- a/src/python39.cfg
+++ b/src/python39.cfg
@@ -23,6 +23,11 @@ environment =
     ${:plat_environment}
     ${python-build:environment}
 
+[python-3.9-build:linux2]
+<= python-3.9-build:default
+plat_environment =
+    LD_RUN_PATH=${opt:location}
+
 [python-3.9-build:darwin-elcapitan]
 <= python-3.9-build:default
 


### PR DESCRIPTION
- document that libtermcap needs to be available so readline and Python can load it.
- set LD_RUN_PATH so the custom shared libraries in parts/... are resolved by ld.so

I'm not 100% certain this is required. On my super-minimal Ubuntu docker container I use to test GH workflows it is needed. On the actual GH workflow environment it is not. Lets see how this change builds.