### PR TITLE
Unbreak Ubuntu 18.04 builds on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - debug_ubuntu1804_gha
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - debug_ubuntu1804_gha
   pull_request:
 
 jobs:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -82,6 +82,8 @@ except ImportError:
             # existing setuptools found, verify version
             ws = pkg_resources.working_set
             existing = ws.by_key.get('setuptools')
+            if existing is not None and not isinstance(existing, (pkg_resources.Distribution, str)):
+                print("DEBUG: existing = %r" % existing)
             if existing not in pkg_resources.Requirement.parse('setuptools<39dev'):
                 # version too new, replace it locally
                 egg = ez['download_setuptools'](

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -84,8 +84,11 @@ except ImportError:
             existing = ws.by_key.get('setuptools')
             if existing is not None and not isinstance(existing, (pkg_resources.Distribution, str)):
                 print("DEBUG: existing = %r" % existing)
-            if existing and existing not in pkg_resources.Requirement.parse('setuptools<39dev'):
-                # version too new, replace it locally
+            if (
+                existing is None
+                or existing not in pkg_resources.Requirement.parse('setuptools<39dev')
+            ):
+                # version too new or a Ubuntu package without egg info, replace it locally
                 egg = ez['download_setuptools'](
                     download_base=ez['DEFAULT_URL'].replace('http:', 'https:'),
                     to_dir=tmpeggs,

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -84,7 +84,7 @@ except ImportError:
             existing = ws.by_key.get('setuptools')
             if existing is not None and not isinstance(existing, (pkg_resources.Distribution, str)):
                 print("DEBUG: existing = %r" % existing)
-            if existing not in pkg_resources.Requirement.parse('setuptools<39dev'):
+            if existing and existing not in pkg_resources.Requirement.parse('setuptools<39dev'):
                 # version too new, replace it locally
                 egg = ez['download_setuptools'](
                     download_base=ez['DEFAULT_URL'].replace('http:', 'https:'),

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -82,7 +82,7 @@ except ImportError:
             # existing setuptools found, verify version
             ws = pkg_resources.working_set
             existing = ws.by_key.get('setuptools')
-            print("existing: %r, to_reload: %r" % (existing, to_reload))
+            print("existing: %r, to_reload: %r, pkg_resources in sys.modules: %r" % (existing, to_reload, "pkg_resources" in sys.modules))
             if (
                 existing is None
                 or existing not in pkg_resources.Requirement.parse('setuptools<39dev')

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -96,7 +96,7 @@ except (ImportError, AttributeError):
 
     if "pkg_resources" in sys.modules:
         assert pkg_resources is not None
-        reload(pkg_resources)
+        del sys.modules["pkg_resources"]
 
     import pkg_resources
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -82,13 +82,13 @@ except ImportError:
             # existing setuptools found, verify version
             ws = pkg_resources.working_set
             existing = ws.by_key.get('setuptools')
-            if existing is not None and not isinstance(existing, (pkg_resources.Distribution, str)):
-                print("DEBUG: existing = %r" % existing)
+            print("existing: %r, to_reload: %r" % (existing, to_reload))
             if (
                 existing is None
                 or existing not in pkg_resources.Requirement.parse('setuptools<39dev')
             ):
                 # version too new or a Ubuntu package without egg info, replace it locally
+                
                 egg = ez['download_setuptools'](
                     download_base=ez['DEFAULT_URL'].replace('http:', 'https:'),
                     to_dir=tmpeggs,

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -7,6 +7,8 @@ Changes
 - Python 3.9.4 ABI fix.
   [mj]
 
+- Make bootstrap.py work in GitHub actions with Ubuntu's `python-setup` package installed.
+
 2021-04-04
 ----------
 


### PR DESCRIPTION
The GitHub Ubuntu 18.04 build image was recently updated to include the `python-setuptools`. This causes two issues:

- there is no egg metadata for `setuptools` we can rely on
- loading our own setuptools egg breaks reload as the pkg_module module is already reloaded